### PR TITLE
Adding raise hand functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Default Shortcut|Operation
 ---|---
 `Ctrl+Shift+D`<br>(`Option+Shift+D` in macOS)|Turn on/off microphone
 `Ctrl+Shift+E`<br>(`Option+Shift+E` in macOS)|Turn on/off camera
+`Ctrl+Shift+H`<br>(`Option+Shift+H` in macOS)|Raise or lower hand
 N/A|Open Meet tab
 
 ### Shortcut keys customization

--- a/entrypoints/background.ts
+++ b/entrypoints/background.ts
@@ -38,6 +38,16 @@ export default defineBackground(() => {
 					});
 					break;
 				}
+				case "toggle-hand": {
+					const targetTabID = await findMeetTab();
+					if (!targetTabID) return;
+
+					void chrome.tabs.sendMessage(targetTabID, {
+						type: "toggleHand",
+					});
+
+					break;
+				}
 				case "activate-meet-tab": {
 					const targetTabID = await findMeetTab();
 					if (!targetTabID) return;

--- a/entrypoints/content.ts
+++ b/entrypoints/content.ts
@@ -26,6 +26,28 @@ export default defineContentScript({
 
 						break;
 					}
+					case "toggleHand": {
+						const combinations: KeyboardEventInit[] = [
+							// Windows / Linux default shortcut
+							{ ctrlKey: true, altKey: true },
+							// macOS default shortcut uses Command + Option
+							{ metaKey: true, altKey: true },
+							// Some locales expect Control + Command
+							{ ctrlKey: true, metaKey: true },
+						];
+
+						for (const combo of combinations) {
+							document.dispatchEvent(
+								new KeyboardEvent("keydown", {
+									key: "h",
+									code: "KeyH",
+									...combo,
+								}),
+							);
+						}
+
+						break;
+					}
 					default: {
 						break;
 					}

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -23,6 +23,13 @@ export default defineConfig({
 				},
 				description: "Toggle Camera",
 			},
+			"toggle-hand": {
+				suggested_key: {
+					default: "Ctrl+Shift+H",
+					mac: "Alt+Shift+H",
+				},
+				description: "Toggle Raised Hand",
+			},
 			"activate-meet-tab": {
 				description: "Open Meet tab",
 			},


### PR DESCRIPTION
I'd also recommend to set shortcuts to ⌘+ctrl+9/⌘+ctrl+8/⌘+ctrl+7 on mac as ones starting with `⌥` are used for inputing chars.